### PR TITLE
Turn on external sharing via org feature

### DIFF
--- a/config/enterprise-scratch-def.json
+++ b/config/enterprise-scratch-def.json
@@ -1,6 +1,9 @@
 {
   "orgName": "Your Company",
   "edition": "Enterprise",
+  "features": [
+        "externalSharing"
+  ],
   "orgPreferences": {
     "enabled": [
       "S1DesktopEnabled"

--- a/config/enterprise-scratch-def.json
+++ b/config/enterprise-scratch-def.json
@@ -2,7 +2,7 @@
   "orgName": "Your Company",
   "edition": "Enterprise",
   "features": [
-        "externalSharing"
+        "ExternalSharing"
   ],
   "orgPreferences": {
     "enabled": [

--- a/config/project-scratch-def.json
+++ b/config/project-scratch-def.json
@@ -1,6 +1,9 @@
 {
     "orgName": "Salesforce DX Company",
     "edition": "Developer",
+    "features": [
+        "externalSharing"
+    ],
     "orgPreferences" : {
         "enabled": ["S1DesktopEnabled"]
     }

--- a/config/project-scratch-def.json
+++ b/config/project-scratch-def.json
@@ -2,7 +2,7 @@
     "orgName": "Salesforce DX Company",
     "edition": "Developer",
     "features": [
-        "externalSharing"
+        "ExternalSharing"
     ],
     "orgPreferences" : {
         "enabled": ["S1DesktopEnabled"]

--- a/force-app/main/default/applications/DreamHouse.app-meta.xml
+++ b/force-app/main/default/applications/DreamHouse.app-meta.xml
@@ -9,21 +9,21 @@
     <formFactors>Large</formFactors>
     <label>DreamHouse</label>
     <navType>Standard</navType>
-    <tab>standard-home</tab>
-    <tab>Property__c</tab>
-    <tab>Broker__c</tab>
-    <tab>standard-Contact</tab>
-    <tab>Property_Explorer1</tab>
-    <tab>Command_Center</tab>
-    <tab>Einstein_Vision</tab>
-    <tab>standard-report</tab>
-    <tab>standard-Dashboard</tab>
-    <tab>standard-Event</tab>
-    <tab>Heat_Map_Mock</tab>
-    <tab>Heat_Map</tab>
-    <tab>Sample_Data_Import</tab>
-    <tab>Bot_Command__c</tab>
-    <tab>standard-File</tab>
+    <tabs>standard-home</tabs>
+    <tabs>Property__c</tabs>
+    <tabs>Broker__c</tabs>
+    <tabs>standard-Contact</tabs>
+    <tabs>Property_Explorer1</tabs>
+    <tabs>Command_Center</tabs>
+    <tabs>Einstein_Vision</tabs>
+    <tabs>standard-report</tabs>
+    <tabs>standard-Dashboard</tabs>
+    <tabs>standard-Event</tabs>
+    <tabs>Heat_Map_Mock</tabs>
+    <tabs>Heat_Map</tabs>
+    <tabs>Sample_Data_Import</tabs>
+    <tabs>Bot_Command__c</tabs>
+    <tabs>standard-File</tabs>
     <uiType>Lightning</uiType>
     <utilityBar>dreamhouseApplicationUtilityBar</utilityBar>
 </CustomApplication>

--- a/force-app/main/default/objects/Property__c/Property__c.object-meta.xml
+++ b/force-app/main/default/objects/Property__c/Property__c.object-meta.xml
@@ -55,7 +55,6 @@
     <enableSearch>true</enableSearch>
     <enableSharing>true</enableSharing>
     <enableStreamingApi>true</enableStreamingApi>
-    <externalSharingModel>ReadWrite</externalSharingModel>
     <label>Property</label>
     <nameField>
         <label>Property Name</label>

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -1,7 +1,7 @@
 {
   "packageDirectories": [
     {
-      "path": "force-app/main/default",
+      "path": "force-app",
       "default": true
     }
   ],

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -1,11 +1,11 @@
 {
   "packageDirectories": [
     {
-      "path": "force-app/main/default",
+      "path": "force-app",
       "default": true
     }
   ],
   "namespace": "",
   "sfdcLoginUrl": "https://login.salesforce.com",
-  "sourceApiVersion": "40.0"
+  "sourceApiVersion": "42.0"
 }

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -1,7 +1,7 @@
 {
   "packageDirectories": [
     {
-      "path": "force-app",
+      "path": "force-app/main/default"
       "default": true
     }
   ],

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -1,7 +1,7 @@
 {
   "packageDirectories": [
     {
-      "path": "force-app/main/default"
+      "path": "force-app/main/default",
       "default": true
     }
   ],


### PR DESCRIPTION
In the next patch, we will more closely mimic the shape of the orgs that we have in production and sandbox. That means that external sharing is no longer turned on by default in scratch orgs. See https://success.salesforce.com/_ui/core/chatter/groups/GroupProfilePage?g=0F93A000000HTp1&fId=0D53A00003SQizw for more information.

*This should be merged only when the next patch goes out next week*.