### PR TITLE
Enable ExternalSharing in scratch orgs

### DIFF
--- a/config/project-scratch-def.json
+++ b/config/project-scratch-def.json
@@ -1,7 +1,8 @@
 {
     "orgName": "Salesforce DX Company",
     "edition": "Developer",
-    "orgPreferences" : {
+    "features": ["ExternalSharing"],
+    "orgPreferences": {
         "enabled": ["S1DesktopEnabled"]
     }
 }


### PR DESCRIPTION
This resolves a bug where ExternalSharing had been disabled by default